### PR TITLE
Use surf instead of reqwest for token POST request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,18 @@ name = "spotify_oauth"
 path = "src/lib.rs"
 
 [dependencies]
-url = "2.0"
+url = "2.1"
 rand = "0.7"
-strum = "0.15"
+strum = "0.17"
 chrono = "0.4"
-reqwest = "0.9"
-dotenv = "0.14"
+surf = "1.0"
+base64 = "0.11"
+dotenv = "0.15"
 serde_json = "1.0"
-strum_macros = "0.15"
+strum_macros = "0.17"
+snafu = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
-open = "1.2"
+async-std = { version = "1.0", features = ["attributes"] }
+open = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotify-oauth"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["FrictionlessPortals <8077147+FrictionlessPortals@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT"
@@ -9,7 +9,7 @@ description = "An implementation of the Spotify Authorization Code Flow in Rust"
 documentation = "https://docs.rs/spotify-oauth/"
 homepage = "https://github.com/FrictionlessPortals/spotify-oauth"
 repository = "https://github.com/FrictionlessPortals/spotify-oauth"
-keywords = ["spotify", "api", "oauth"]
+keywords = ["spotify", "api", "oauth", "async"]
 exclude = [
     ".env.example",
     ".env",

--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@
 spotify-oauth is a library for [Spotify Authorization](https://developer.spotify.com/documentation/general/guides/authorization-guide/).
 It features a full implementation of the Authorization Code Flow that Spotify requires a user to undergo before using the web API.
 
-## Installation
-
-```shell
-cargo install spotify-oauth
-```
-
 ## Basic Example
 This example shows how the library can be used to create a full authorization flow for retrieving the token required to use the web API.
 ```rust

--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ It features a full implementation of the Authorization Code Flow that Spotify re
 ## Basic Example
 This example shows how the library can be used to create a full authorization flow for retrieving the token required to use the web API.
 ```rust
-use std::io::stdin;
-use std::str::FromStr;
-use spotify_oauth::{SpotifyAuth, SpotifyCallback};
+use std::{io::stdin, str::FromStr, error::Error};
+use spotify_oauth::{SpotifyAuth, SpotifyCallback, SpotifyScope};
 
-fn main() -> Result<(), Box<std::error::Error>> {
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     // Setup Spotify Auth URL
-    let auth_url = SpotifyAuth::default().authorize_url()?;
+    let auth = SpotifyAuth::new_from_env("code".into(), vec![SpotifyScope::Streaming], false);
+    let auth_url = auth.authorize_url()?;
 
     // Open the auth URL in the default browser of the user.
     open::that(auth_url)?;
@@ -24,7 +25,9 @@ fn main() -> Result<(), Box<std::error::Error>> {
     let mut buffer = String::new();
     stdin().read_line(&mut buffer)?;
 
-    let token = SpotifyCallback::from_str(buffer.trim())?.convert_into_token()?;
+    // Convert the given callback URL into a token.
+    let token = SpotifyCallback::from_str(buffer.trim())?
+        .convert_into_token(auth.client_id, auth.client_secret, auth.redirect_uri).await?;
 
     println!("Token: {:#?}", token);
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,25 @@
+use spotify_oauth::{SpotifyAuth, SpotifyCallback, SpotifyScope};
+use std::{error::Error, io::stdin, str::FromStr};
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    // Setup Spotify Auth URL
+    let auth = SpotifyAuth::new_from_env("code".into(), vec![SpotifyScope::Streaming], false);
+    let auth_url = auth.authorize_url()?;
+
+    // Open the auth URL in the default browser of the user.
+    open::that(auth_url)?;
+
+    println!("Input callback URL:");
+    let mut buffer = String::new();
+    stdin().read_line(&mut buffer)?;
+
+    // Convert the given callback URL into a token.
+    let token = SpotifyCallback::from_str(buffer.trim())?
+        .convert_into_token(auth.client_id, auth.client_secret, auth.redirect_uri)
+        .await?;
+
+    println!("Token: {:#?}", token);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,13 +469,15 @@ impl SpotifyCallback {
         // Form authorisation header.
         let auth_value = base64::encode(&format!("{}:{}", client_id, client_secret));
 
+        // POST the request.
         let mut response = surf::post(SPOTIFY_TOKEN_URL)
-            .set_header("Authorization", auth_value)
+            .set_header("Authorization", format!("Basic {}", auth_value))
             .body_form(&payload)
             .unwrap()
             .await
             .context(SurfError)?;
 
+        // Read the response body.
         let buf = response.body_string().await.unwrap();
 
         if response.status().is_success() {


### PR DESCRIPTION
This commit converts the ``convert_into_token`` function to use ``surf``'s POST instead of ``reqwest``'s POST. This change enables the function to be asynchronous.

While ``reqwest`` is getting asynchronous I/O support, ``surf`` has fewer build dependencies which reduces it from 212 to 119.

This pull request also contains a error type rework with ``snafu``.

These changes are breaking changes and the crate should be bumped to 0.3.0 when released.